### PR TITLE
Langsmith integration

### DIFF
--- a/albums.txt
+++ b/albums.txt
@@ -1,0 +1,78 @@
+It All Comes Down To This
+Night Reign
+Free Fallin'
+Death Jokes
+Cartoon Darkness
+Mirror, Reflect
+Another Taste
+Synthesizer
+God Said No
+Shadows
+Silence Is Loud
+Home
+The Whole Story
+4ever
+Bad Bad Hats
+Harvest
+The Dream of Delphi
+Rivers
+This Is How Tomorrow Moves
+Everybody Can't Go
+Ten Fold
+Feu de garde
+Puzzles
+Ohio Players
+Ohio Players
+Absolute Elsewhere
+Heart of the Artichoke
+Dennis
+Boeckner!
+Sounds Good
+K
+Five Dice, All Threes
+Affection
+Look to the East, Look to the West
+Constellation
+Honey
+Songwriter
+Tides
+Wild God
+Your Day Will Come
+BRAT
+Live Laugh Love
+Cool World
+The Joy of Sects
+The Joy of Sects
+X's
+Final Summer
+2
+Paint a Room
+The Gloss
+Love To You, Mate
+The Auditorium Vol. 1
+Britpop
+Britpop
+Been Here Before
+New Last Name
+Red Mile
+Red Mile
+AMAMA
+To the Ghosts
+Ramona
+Another Heaven
+Devourer
+ROCKMAKER
+Image Issues
+Sistrionix 2.0
+Still
+As It Ever Was, So It Will Be Again
+Poetry
+Delicate Steve Sings
+What's For Breakfast?
+Black Ocean
+Weird Faith
+Alligator Bites Never Heal
+Festina Lente
+Dr. Dog
+Dr. Dog
+PRUDE

--- a/bands.txt
+++ b/bands.txt
@@ -1,0 +1,140 @@
+2nd Grade
+A Certain Ratio 
+Acid Tongue 
+Acid Tongue
+Arooj Aftab 
+Aili 
+Amen Dunes 
+Kyle Andrews 
+Another Taste 
+Another Taste
+Omar Apollo 
+Arab Strap 
+Nia Archives 
+Arcwelder 
+Armlock 
+Daymé Arocena 
+Daymé Arocena 
+Aurora 
+Babehoven 
+Bab L' Bluz 
+Baby Rose & BADBADNOTGOOD 
+Bacao Rhythm & Steel Band 
+Bad Bad Hats 
+Liam Bailey 
+Kishi Bashi 
+Blick Bassy 
+Bat for Lashes 
+Beak> 
+Beak>
+Beautiful Freaks 
+Beautiful Freaks
+Been Stellar 
+Being Dead 
+The Belair Lip Bombs 
+Cecile Believe 
+Benny the Butcher 
+Beyoncé 
+Yaya Bey 
+Bibi Club 
+​Kasper Bjørke 
+The Black Keys 
+Black Nite Crash 
+Black Nite Crash
+Abbey Blackwell
+Karl Blau 
+The Blessed Madonna 
+Blitzen Trapper 
+Blood Incantation 
+Bloomsday 
+Jake Blount & Mali Obomsawin 
+Blue Lab Beats 
+Blushing 
+Blxst 
+Bnny 
+Naima Bock 
+Sega Bodega 
+Body Meat 
+Ben Böhmer 
+Ben Böhmer 
+Bombay Bicycle Club 
+Bondax 
+Bon Iver 
+Bonny Light Horseman
+Jessica Boudreaux
+Boyscott
+Muireann Bradley 
+Muireann Bradley 
+Branko 
+Chelsea Bridge 
+Leon Bridges 
+Bright Eyes
+Broadcast - Spell Blanket 
+Broadcast - Spell Blanket
+The Bug Club 
+Bullion 
+Cadence Weapon 
+Caius 
+Cakes da Killa 
+John Cale 
+Camera Obscura
+Canblaster 
+Carsick Cars 
+Johnny Cash 
+Casino Hearts 
+Catching Flies 
+Céu 
+Chalk 
+Chanel Beads 
+Chanel Beads 
+Charly Bliss 
+Chastity Belt
+Chat Pile 
+Cheekface 
+Chicano Batman 
+Chinese American Bear 
+Chromeo 
+Cigarettes After Sex 
+Cimafunk 
+Clairo 
+Gary Clark Jr. 
+Cloud Nothings 
+Cola 
+Cold Cave 
+Louis Cole (with Metropole Orkest & Jules Buckley) 
+Louis Cole (with Metropole Orkest & Jules Buckley) 
+Common & Pete Rock 
+Confidence Man
+A. G. Cook 
+Cool Out Sun 
+Crack Cloud 
+Crows 
+Cuffed Up 
+Cults 
+Grace Cummings 
+CunninLynguists 
+The Cure 
+Denzel Curry 
+Curses 
+Cursive 
+The Dandy Warhols 
+Douglas Dare 
+Jean Dawson 
+Yussef Dayes 
+Deap Vally 
+Erika de Casier 
+The Decemberists 
+Dehd 
+Dehd
+Delicate Steve 
+Dent May 
+Diary 
+Madi Diaz 
+DIIV 
+The Dip 
+Discovery Zone 
+DJ Sabrina the Teenage DJ 
+Doechii 
+Dr. Dog 
+Drug Church 
+Ducks Ltd. 

--- a/file_empty.py
+++ b/file_empty.py
@@ -1,0 +1,6 @@
+class FileEmpty(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return f"FileEmpty: {self.message}"

--- a/kexp_albums_24.txt
+++ b/kexp_albums_24.txt
@@ -1,0 +1,783 @@
+ Duendita - the mind is a miracle
+ Dumbo Tracks - Move With Intention
+ Dummy - Free Energy
+ Matt Duncan - I will Write Your Song
+ Danielle Durack - Escape Artist
+ Adanna Duru - Nappy Hour II EP
+ Eaglemont - Party Boy
+ Early Internet - Ruminator
+ Earthtones - We Can Live Together
+ Easy Sleeper - A Sacred Way of Living
+ Ebbb - All At Once
+ Eels - Eels Time!
+ Efterklang - Things We Have In Common
+ Ekko Astral - pink balloons
+ EKKSTACY - EKKSTACY
+ elbow - AUDIO VERTIGO
+ Elephant Stone - Back Into The Dream
+ Elkka - Prism of Pleasure
+ ellis - No Place That Feels Like
+ El Perro del Mar - Big Anonymous
+ meg elsier - spittake
+ EMEL - MRA
+ Empress Of - For Your Consideration
+ English Teacher - This Could Be Texas
+ Enumclaw - Home in Another Life
+ Erick The Architect - I've Never Been Here Before
+ Alejandro Escovedo - Echo Dancing
+ Etran de L’Aïr - 100% Sahara Guitar
+ Sam Evian - Plunge
+ Ezra Collective - Dance, No One's Watching
+ Fake Fruit - Mucho Mistrust
+ Fantastic Negrito - Son of a Broken Man
+ Fashion Club - A Love You Cannot Shake
+ Fastbacks - For WHAT Reason!
+ Fat Dog - WOOF.
+ Father John Misty - Mahashmashana
+ Fcukers - Baggy$$ EP
+ Fennec - Nice Work Vol. 3
+ Ibelisse Guardia Ferragutti & Frank Rosaly - MESTIZX
+ Lupe Fiasco - Samurai
+ Fievel Is Glaque - Rong Weicknes
+ Jamie Finlay - Sun Dogs
+ Kelly Finnigan - A Lover Was Born
+ Finom - Not God
+ Fir Cone Children - Jig of Glee
+ Montell Fish - CHARLOTTE
+ Flamingo Pier - Supro EP
+ Flight Mode - The Three Times
+ Floating Points - Cascade
+ Flying Lotus - Spirit Box EP
+ foamboy - Eating Me Alive
+ The Folk Implosion - Walk Thru Me
+ Jerry Folk - Heart
+ Folly Group - Down There!
+ Font - Strange Burden
+ Fontaines D.C. - Romance
+ Katrina Ford - H.E.A.R.T.
+ Forest Ray - Windfucker (jjebivjetar)
+ Alex Henry Foster - Kimiyo
+ Found Space - Closer
+ Four Tet - Three
+ The Fourth Wall - Return Forever
+ Fousheé - Pointy Heights
+ Hannah Frances - The Keeper of the Shepherd
+ Francis of Delirium - Lighthouse
+ Mabe Fratti - Sentir Que No Sabes
+ Aaron Frazer - Into The Blue
+ Freak Slug - I Blow Out Big Candles
+ Fred again.. - ten days
+ freekind. - Since Always and Forever
+ Amaro Freitas - Y'Y
+ French Cassettes - Benzene
+ Mumu Fresh - The Healing
+ Friedberg - Hardcore Workout Queen
+ Friko - Where we've been, Where we go from ehre
+ Frog - GROG
+ Fucked Up - Another Day
+ Full Flower Moon Band - MEGAFLOWER
+ Jake Xerxes Fussell - When I'm Called
+ Future Islands - People Who Aren't There Anymore
+ Rui Gabriel - Compassion
+ Liam Gallagher & John Squire - Liam Gallagher & John Squire
+ Childish Gambino - Bando Stone & the New World
+ Angélica Garcia - Gemelo
+ Nubya Garcia - Odyssey
+ GARDENS - Flaws
+ Dana Gavanski - LATE SLAP
+ Mk.gee - Two Star & The Dream Police
+ GEMZ - See the Future EP
+ Gen and the Degenerates - ANTI-FUN PROPAGANDA
+ gglum - The Garden Dream
+ GHLOW - Levitate
+ Ghost Funk Orchesra - A Trip To The Moon
+ Ghostly Kisses - Darkroom
+ Ghost Piss - Dream Girl
+ Beth Gibbons - Lives Outgrown
+ GIFT - Illuminator
+ Ginger Root - SHINBANGUMI
+ LP Giobbi - Dotr
+ Girl and Girl - Call A Doctor
+ girl in red - I'M DOING IT AGAIN BABY!
+ Girl Ultra - blush EP
+ John Glacier - Like a Ribbon EP
+ glass beach - plastic death
+ Glass Beams - Mahal EP
+ Goat - Goat
+ Goat Girl - Below The Waste
+ Joe Goddard - Harmonics
+ Godspeed You! Black Emperor - “NO​ ​TITLE AS OF 13 FEBRUARY 2024 28​,​340 DEAD”
+ Good Looks - Lived Here For A While
+ Good Morning - Good Morning Seven
+ Kim Gordon - The Collective
+ Gossip - Real Power
+ Goth Babe - LOLA
+ Peggy Gou - I Hear You
+ Laura Jane Grace - Hole in My Head
+ Grandaddy - Blu Wav
+ John Grant - The Art of the Lie
+ Gracie Gray - Magnet
+ Saya Gray - QWERTY II EP
+ Grumpy - Wolfed EP
+ Tama Gucci - Notes To Self
+ Guided Boy Voices - Strut Of Kings
+ Gulfer - Third Wind
+ GUM & Ambrose Kenny-Smith - Ill Times
+ Gurriers - Come and See
+ Gustaf - Package, Pt. 2
+ Gut Health - Stiletto
+ Dave Guy - Ruby
+ Habibi - Dreamachine
+ Marika Hackman - Big Sigh
+ Haich Ber Na - The Everyday
+ Haldi & ans Flamingo - Õige aeg
+ Half Waif - See You At The Maypole
+ Half Waif - Ephemeral Being EP
+ Halima - EXU EP
+ Nigel Hall & DJ Harrison - The Burning Bush: A Journey Through the Music of Earth, Wind & Fire
+ Marla Hansen - Salt
+ The Hard Quartet - The Hard Quartet
+ The Harlem Gospel Travelers - Rhapsody
+ DJ Harrison - Shades of Yesterday
+ Keyon Harrold - Foreverland
+ Yasmin Hass - Worst of Me EP
+ Hataałii - Waiting For A Sign
+ Maya Hawke - Chaos Angel
+ kiko hayashi - lost
+ The Headhunters - The Stunt Man
+ The Heavy Heavy - One of a Kind
+ HEEMS - VEENA
+ Heems & Lapgan - LAFANDAR
+ Hello Mary - Emita Ox
+ Sean Henry - Head
+ Hermanos Gutiérrez - Sonido Cósmico
+ Haley Heynderickx - Seed of a Seed
+ Hiatus Kaiyote - Love Heart Cheat Code
+ High Fruit - Kumar
+ HighSchool - Accelerator
+ High Vis - Guided Tour
+ Hildegard - Jour 1596
+ Hinds - VIVA HINDS
+ Holiday Ghosts - Coat of Arms
+ Hollow Ship - Animated Music
+ Julia Holter - Something in the Room She Moves
+ Honeyglaze - Real Deal
+ Hoorsees - Big
+ Horse Jumper of Love - Disaster Trick
+ Hot Moms Club - Happy You're Here
+ Hovvdy - Hovvdy
+ Brittany Howard - What Now
+ How To Dress Well - I Am Toward You
+ Fana Hues - Moth
+ Humdrum - Every Heaven
+ Nailah Hunter - Lovegaze
+ Hurray For The Riff Raff - The Past Is Still Alive
+ HYUKOH & Sunset Rollercoaster - AAA
+ Ibibio Sound Machine - Pull the Rope
+ IDLES - TANGK
+ illuminati hotties - POWER
+ Indian Man - Gran's House
+ Inkswel - Space Vaults
+ inuha - 陽のかけら / Hi No Kakera EP
+ Iron & Wine - Light Verse
+ ISHA - What You're Seeing
+ Islands - What Occurs
+ IS U IS U - Melter EP
+ Itasca - Imitation of War
+ IYAMAH - In Two Worlds
+ Leifur James - Magic Seeds
+ Jamie xx - In Waves
+ Japandroids - Fate & Alcohol
+ Bryony Jarman-Pinto - Below Dawn
+ Merryn Jeann - Dog Beach
+ Jembaa Groove - Ye Ankasa | We Ourselves
+ Cassandra Jenkins - My Light, My Destroyer
+ The Jesus And Mary Chain - Glasgow Eyes
+ jigitz - don't come back
+ Jlin - Akoma
+ Nathalie Joachim - Ki moun ou ye
+ Jordana - Lively Premonition
+ José Junior - Spanish Leather
+ Josephine - Leaning EP
+ Allysha Joy - The Making of Silk
+ Joyce - Voyce
+ J.R.C.G. - Grim Iconic ... (Sadistic Mantra)
+ JSWISS - You Never Really Know
+ Judeline - Bodhiria
+ juicer - Retire the Fences
+ julie - my anti-aircraft
+ Juniore - Trois, Deux, Un
+ Justice - Hyperdrama
+ Kairos Creature Club - Kairos Creature Club
+ Kaleida - In Arms
+ Karate Boogaloo - Hold Your Horses
+ Kasbo - The Learning of Urgency
+ Kaytranada - Timeless
+ Keaper - Waking Dream
+ Kehlani - CRASH
+ Kerosene Kream - Buying Time
+ Khana Bierbood - Monolam
+ Khruangbin - A LA SALA
+ Ki! - Yong-Gwanglo Part One
+ Kiasmos - II
+ Kiefer - Something For Real
+ Killer Mike - Michael & The Mighty Midnight Revival: Songs For Sinners And Saints
+ Kindsight - No Shame No Fame
+ King GIzzard & the Lizard Wizard - Flight B741
+ King Hannah - Big Swimmer
+ King Pari - There It Goes
+ Katy Kirby - Blue Raspberry
+ Kito - BIMYOU
+ Kitty Ca$h - Handle With Care
+ Klaus Johann Grobe - lo Tu il Loro
+ Klaverson - Reflections
+ K.O.G. - Don't Take My Soul
+ KOKOKO! - BUTU
+ Kokoroko - Get the Message
+ Mo Kolours - Original Flow
+ Loren Kramar - Glovemaker
+ KUČKA - Can You Hear Me Dreaming?
+ Lia Kuri - Motherland
+ Kurious - Majician
+ Seun Kuti & Egypt 80 - Heavier Yet (Lays the Crownless Head)
+ LAIR - Ngélar
+ LA LOM - The Los Angeles League Of Musicians
+ La Luz - News Of The Universe
+ Kendrick Lamar - GNX
+ Lamplight - Lamplight
+ LA Priest - LA Fusion
+ Laraw - Quarter Life Criss
+ Large Brush Collection - Off Center
+ Lava La Rue - STARFACE
+ Clara La San - Made Mistakes
+ La Sécurité - Stay Safe! REMIXED
+ Las Nubes - Tormentas Malsanas
+ The Last Dinner Party - Prelude to Ecstasy
+ Late Bloomer - Another One Again
+ Forest Law - Zero
+ LEATHERS - Ultraviolet
+ Oisin Leech - Cold Sea
+ Cindy Lee - Diamond Jubilee
+ Kelly Lee Owens - Dreamstate
+ Merce Lemon - Watch Me Drive Them Dogs Wild
+ The Lemon Twigs - A Dream Is All We Know
+ Ravyn Lenae - Bird's Eye
+ MJ Lenderman - Manning Fireworks
+ Adrianne Lenker - Bright Future
+ Les Amazones d'Afrique - Musow Danse
+ Lesibu Grand - Triggered
+ Les Savy Fav - OUI, LSF
+ levitation room - Strange Weather
+ Cassandra Lewis - Lost In A Dream
+ Leyya - Half Asleep
+ Lightheaded - Combustible Gems
+ Luna Li - When a Thought Grows Wings
+ Lime Garden - One More Thing
+ L’Impératrice - Pulsar
+ The Linda Lindas - No Obligation
+ Lip Critic - Hex Dealer
+ Liraz - Enerjy – انرژی
+ Little SImz - Drop 7
+ LL Cool J - THE FORCE
+ Local Natives - But I'll Wait For You
+ Jess Locke - Real Life
+ Logic1000 - Mother
+ Lollise - I hit the water
+ Loma - How Will I Live Without A Body
+ ​​Mira Ló - Tribute To Chicago EP
+ London Afrobeat Collective - Esengo
+ London Grammar - The Greatest Love
+ Lonesome Shack - Song Of The Horse
+ Los Bitchos - Talkie Talkie
+ Los Campesinos! - All Hell
+ The Lostines - Meet The Lostines
+ Romeo Louisa - Indigo Chronicles
+ Wyatt C. Louis - Chandler
+ Loving - Any Light
+ Rosie Lowe - Lover, Other
+ LSDXOXO - DOGMA
+ Lunar Vacation - Everything Matters, Everything's Fire
+ Lunchbox - Pop and Circumstance
+ Lutalo - The Academy
+ Lyrics Born - Goodbye, Sticky Rice
+ Machinedrum - 3FOR82
+ Jordan Mackampa - WELCOME HOME, KID
+ Mad Foxes - Inner Battles
+ Magdalena Bay - Imaginal Disk
+ Magic Fig - Magic Fig
+ Mahawam - Hot Pressed
+ MAITA - want
+ Makèz - Midnight Time EP
+ Mali Obomsawin and Magdalena Abrego - Greatest Hits
+ MaLLy & Last Word - The Sweetest of It All
+ Kiazi Malonga - Zu Dia Ngoma
+ Mama Zu - Quilt Floor
+ Manatee Commune - Simultaneity (同時性)
+ Mandy - Lawn Girl
+ Man Man - Carrot On Strings
+ Mannequin Pussy - I Got Heaven
+ Manners Manners - I Held Their Eyes, I Kissed Them All
+ Man/Woman/Chainsaw - Eazy Peazy EP
+ Marcel Wave - Something Looming
+ Briana Marela - Teardrop Star
+ Margaux - Inside the Marble
+ The Marías - submarine
+ Laura Marling - Patterns in Repeat
+ mary in the junkyard - this old house EP
+ J Mascis - What Do We Do Now
+ Masok - challenge accepted
+ Randy Mason - Practical Rap for Everyday People
+ Daudi Matsiko - The King of Misery
+ Matty - POPS
+ Maud - The Love That Remains
+ Halo Maud - Celebrate
+ Maxband - On Ice
+ Katie McBride - THE ANGELS ARE CALLING
+ Leyla McCalla - Sun Without The Heat
+ Adriana McCassim - See It Fades
+ Jon McKiel - Hex Dealer
+ Eliza McLamb - Going Through It
+ MC Lyte - 1 of 1
+ Angie McMahon - Light Sides EP
+ Meata - Endless Night
+ Meatbodies - Flora Ocean Tiger Bloom
+ Mediocre - Growth Eater
+ mega cat - mega cat
+ Meklit - Ethio Blue EP
+ MEMORIALS - Memorial Waterslides
+ Menomena - The Insulation EP
+ Meridian Brothers - Mi Latinoamérica Sufre
+ Mestio Beat - Jaraguá
+ Meth Math - Chupetones
+ METZ - Up On Gravity Hill
+ Mexican Institute of Sound - Algo-Ritmo : Mexican Institute of Sound Hits 2004 - 2024
+ MGMT - Loss of Life
+ MICHELLE - Songs About You Specifically
+ MICHELLE - GLOW
+ MIddle Kids - Faith Crisis Pt 1
+ Nicole Miglis - Myopia
+ MIldlife - Chorus
+ Mild Universe - Everything Must Change
+ Militarie Gun - Life Under the Sun
+ Mindchatter - This Is A Reminder That You Are Not Behind Your Face
+ Miners - A Healthy Future on Earth
+ Mini Trees - Burn Out EP
+ MLiR - Pulpo Fiction
+ Moby - always centered at night
+ Mdou Moctar - Funeral For Justice
+ Solo Moderna & Krage - Daïsm
+ Modern English - 1 2 3 4
+ Mo Dotti - opaque
+ Moin - You Never End
+ Molchat Doma - Belaya Polosa
+ Molina - When You Wake Up
+ Joya Mooi - Open Hearts EP
+ Mikey Moo - Fresh Idiot
+ Thurston Moore - Flow Critical Lucidity
+ Moor Mother - The Great Bailout
+ Sam Morton - Daffodils & Dirt
+ Gilligan Moss - Speaking Across Time
+ Mount Eerie - Night Palace
+ Mount Kimbie - The Sunset Violent
+ MRCY - VOLUME 1
+ Mr. Gnome - A Sliver of Space
+ Mt Fog - ultraviolet heart machine
+ Mueran Humanos - Reemplazante
+ Angela Muñoz - Descanso
+ Crystal Murray - SAD LOVERS & GIANTS
+ musclecars - Sugar Honey Iced Tea!
+ Mustafa - Dunya
+ Mutant Academy - Keep Holly Alive
+ MYAAP - BIG MYAAP, NOT THE LIL ONE EP
+ The Mystery Lights - Purgatory
+ naafi - UVA
+ Nada Surf - Moon MIrror
+ NAIMA - City Lights
+ Naked Giants - Shine Away
+ Naked Roommate - Pass the Loofah
+ Nalepa - The Flowers
+ Nap Eyes - The Neon Gate
+ The Narcotix - Dying
+ Milton Nascimento & esperanza spalding - MIlton + esperanza
+ Miles Nautu - Allude EP
+ Meshell Ndegeocello - No More Water: The Gospel of James Baldwin
+ Negative Shawdy - Dancing with the Lights Out
+ Helado Negro - Phasor
+ Willie Nelson - The Border
+ Willie Nelson - Last Leaf on the Tree
+ Autre Ne Veut - Love, Guess Who??
+ New Age Healers - The Spin Out
+ Newen Afrobeat - Grietas
+ Ngwaka Son Systéme - Iboto Ngenge
+ Nice Biscuit - SOS
+ NIghtshift - Homosapien
+ Night Tapes - assisted memories
+ Janko Nilovic, JJ Whitefield & Igor Zhukovsky - Cosmos Giants
+ Molly Nilsson - Un-American Activities
+ J Noa - Mátense por la Corona
+ Non La - Like Before
+ Nourished By Time - Catching Chickens
+ Nouvelle Vague - Should I Stay Or Should I Go
+ No Windows - Point Nemo
+ Nox Novacula - Feed the Fire
+ Nubiyan Twist - Find Your Flame
+ NxWorries - Why Lawd?
+ O. - Weirdos
+ Oceanator - Everything is Love and Death
+ Oddisee - And Yet Still EP
+ Lewis OfMan - Cristal Medium Blue
+ of Montreal - Lady on the Cusp
+ OHR - Afterglow
+ Oh, Rose - Dorothy
+ OK Cowgirl - Couldn't Save Us From My Gut
+ OMBIIGIZI - SHAME
+ Omni - Souvenir
+ One True Pairing - Endless Rain
+ Eeba Ooba - Let Your Fire Touch Me
+ ORB - Tailem Bend
+ Orion Sun - Orion
+ Orlas - Viver o Mar
+ Orogne - Chimera
+ Orquesta Akokán - Caracoles
+ Oruã - Passe
+ Osees - SORCS 80
+ Oso Oso - life till bones
+ Otrotasce - Dispatches From Solitude
+ Abdallah Oumbadougou - AMGHAR: The Godfather of Tuareg Music, Vol. 1
+ Our Girl - The Good Kind
+ Christopher Owense - I Wanna Run Barefoot Through Your Hair
+ PACKS - Melt The Honey
+ Painted Shield - Painted Shield 3
+ Pale Jay - Low End Love Song
+ Fabiana Palladino - Fabiana Palladino
+ Jerry Paper - Inbetweezer
+ Parannoul (파란노을) - Sky Hundred
+ Parlor Greens - In Green We Dream
+ Parship - Behold
+ Party Dozen - Crime In Australia
+ PawPawRod - Doobie Mouth
+ Pearl Jam - Dark Matter
+ Pearl & The Oysters - Planet Pearl
+ Orville Peck - Stampede
+ Pedro The Lion - Santa Cruz
+ PEEL - Acid Star
+ Peel Dream Magazine - Rose Main REading Room
+ Nathy Peluso - Grasa
+ Jane Penny - Surfacing
+ Lee "Scratch" Perry - King Perry
+ Pet Shop Boys - Nonetheless
+ Phantogram - Memory of a Day
+ Phantom Handshakes - Sirens at Golden Hour
+ Pile - Hot Air Balloon EP
+ Pillow Queens - Name Your Sorrow
+ yunè pinku - Scarlet Lamb EP
+ Pissed Jeans - Half Divorced
+ Pixies - The Night the Zombies Came
+ {Plus/Minus} - Further Afeild
+ Pokey LaFarge - Rhumba Country
+ Pom Poko - Champion
+ Pom Pom Squad - Mirror Starts Moving WIthout Me
+ Pond - STUNG!
+ Matt Pond PA & Alexa Rose - Call and Response EP
+ Porches - Shirt
+ porij - Teething
+ Porridge Radio - Clouds In The Sky They Will Always Be There For Me
+ Potatohead People - Eat Your Heart Out
+ Pouty - Forgot About Me
+ Jessica Pratt - Here in the Pitch
+ Prim - Move Too Slow
+ Project Geini - Colours & Light
+ PS5 - Echologia
+ Psymon Spine - Head Body Connector
+ Bolis Pupul - Letter to Yu
+ Pure Hex - Spilling
+ Quivers - Oyster Cuts
+ Rahim Redcar - HOPECORE
+ RAH & The Ruffcats - Orile to Berlin
+ Jordan Rakei - The Loop
+ Cassie Ramone - Sweetheart
+ Tyler Ramsey - New LOst Ages
+ Maya Randle - Focus
+ Maya Randle - composure
+ Rapsody - Please Don't Cry
+ Rasco - Dmaot
+ Raveena - Where The Butterflies Go in the Rain
+ Razor Braids - Big Wave
+ Gerry Read - Not Quite There Yet
+ Real Estate - Daniel
+ Red Ribbon - Red Ribbon
+ The Reds, Pinks & Purples - Unwishing Well
+ Niamh Regan - Come As You Are
+ Reyna Tropical - Malegría
+ Gruff Rhys - Sadness Sets Me Free
+ Dawn Richard & Spencer Zahn - Quiet in a World Full of Noise
+ Ride - Interplay
+ Phoebe Rings - Phoebe Rings
+ Liv Rion - WRLD CRY
+ RIP Dunes - RIP Dunes
+ RIP Swirl - Perfectly Blue
+ RiTchie - Triple Digits [112]
+ RJD2 - Visions Out Of Limelight
+ Robber Robber - Wild Guess
+ Bruk Rogers - Loopholes
+ Maggie Rogers - Don't Forget Me
+ Natascha Rogers - Onaida
+ Lau Ro - Cabana
+ Elias Rønnenfelt - Heavy GLory
+ Rosali - Bite Down
+ Rose Hotel - A Pawn Surrender
+ Jimetta Rose & The Voices of Creation - Things Are Getting Better
+ Roshâni - Alma de Baile
+ Devon Ross - Oxford Gardens EP
+ Royel Otis - PRATTS & PAIN
+ RUB - RUB
+ Alice Russell - I Am
+ Ruthven - Rough & Ready
+ Sababa 5 & Yurika - Kokoro
+ Afla Sackey & Afrik Bawantu - Destination
+ Laetitia Sadier - Rooting For Love
+ Dua Saleh - I SHOULD CALL THEM
+ Salt Cathedral - Before It's Gone
+ salute - TRUE MAGIC
+ Jeymes Samuel - THE BOOK OF CLARENCE (The Motion Picture Soundtrack)
+ Ale San - Martian Levitation
+ Sango - North Vol. 2
+ Jalen Santoy & KAMAE - A Story For Later
+ SAULT - Acts of Faith
+ SAVAK - Flavors of Paradise
+ Savan - Antes del Amancer
+ Caroline Says - The Lucky One
+ Vessna Scheff - NEVERMIND THE MOON
+ Screaming Females - Clover EP
+ Sea Caves - Everything Moves
+ Seafood Sam - Standing on Giant Shoulders
+ Kit Sebastian - New Internationale
+ Ty Segall - Three Bells
+ Selmer - Body Wash
+ Mei Semones - Kabutomushi EP
+ serpentwithfeet - GRIP
+ Seven Davis Jr. - Stranger Than Fiction
+ Sex Week - Sex Week
+ Shabaka - Perceive Its Beauty, Acknowledge Its Grace
+ Shabazz Palaces - Exotic Birds of Prey
+ The Shacks - Big Crown Vaults Vol. 2
+ Shad & 14KT - Reel Speakers
+ Shad x TLO - THIS WINTER
+ Shannon & The Clams - The Moon Is In the Wrong Place
+ Sheer Mag - Playing Favorites
+ Shelf Nunny - Pronoia
+ Shigeto - Cherry Blossom Baby
+ Shovles & Rope - Something Is Working Up Above My Head
+ Shower Curtain - words from a wishing well
+ shygirl - Club Shy EP
+ Silverbacks - Easy Being A Winner
+ Silver Skylarks - The Number One Set and Sound
+ Sinkane - We Belong
+ Sis - Vibhuti
+ The Slaps - Mudglimmer
+ Sleater-Kinney - Little Rope
+ Sleater-Kinney - Frayed Rop Sessions
+ Sleeping Bag - Beam Me Up
+ Erick Slick - New Age Rage
+ SLIFT - ILION
+ Slow Spirit - That's the Gods Talking
+ SLUGS - in btwn
+ Slum Village - F.U.N.
+ Sly5thAve - Liberation
+ The Smile - Wall of Eyes
+ The Smile - Cutouts
+ Snakehips & EARTHGANG - SNAKEGANG EP, Vol. 1
+ Snoozer - Mid-Earth
+ Soccer Mommy - Evergreen
+ Sofi Tukker - BREAD
+ Softcult - Heaven
+ The Softies - The Bed I Made
+ Soft Loft - The Party and the Mess
+ Vera Sola - Peacemaker
+ somesurprises - Perseids
+ Astrid Sonne - Great Doubt
+ Sons of Sevilla - Lullabies for a Wildcat
+ SOPHIE - SOPHIE
+ Josiah Soren - Samurai
+ Omar Souleyman - Erbil
+ The Soundcarriers - Through Other Reflections
+ The South Hill Experiment - South Hill & Friends
+ Soweto Gospel Choir x Groove Terminator - History of House
+ Alena Spanger - Fire Escape
+ Alan Sparhawk - White Roses, My God
+ Speakers Corner Quartet - Mr Loverman (Original Score)
+ Spectres - Presence
+ Spiral XP - I Wish I Was A Rat
+ SPIRIT OF THE BEEHIVE - YOU'LL HAVE TO LOSE SOMETHING
+ SPRINTS - Letter To Self
+ Louisa Stancioff - When We Were Looking
+ Star Anna - Love and Sex and Fear of Death
+ Starflyer 59 - Lust for Gold
+ Steen - Memory is Hunger
+ Sophia Stel - Object Permanence EP
+ Stereolab - Little Pieces of Stereolab (A Switched On Sampler)
+ Still Corners - Dream Talk
+ Strand of Oaks - Miracle Focus
+ Strangelily - A Strange Film, Featuring You and I
+ Strangerfamiliar - La Pena
+ Chuck Strangers - A Forsaken Lover's Plea
+ STRFKR - Parallel Realms
+ St. Vincent - All Born Screaming
+ SUGARFUNGUS - A Known Thing
+ Suite SImone - Bird
+ Moses Sumney - Sophcore EP
+ Sun Atlas - Return to the Spirit
+ Sunflower Bean - Shake EP
+ Sunset Rubdown - Always Happy To Explode
+ Susanna - Meditations on Love
+ Swirls - Top of the Line
+ Swiss Portrait - Someday
+ SYBS - Olew Nadroedd
+ Sycco - Zorb
+ Mohammad Syfkhan - I Am Kurdish
+ Soshi Takeda - Secret Communication
+ Talaya. - c l E a R.
+ Tall Juan - Raccoon Nights
+ TAMTAM - Ramble in the Rainbow
+ Tanukichan - Circles EP
+ Tara Lily - Speak in the Dark
+ Tasha - All This and So Much More
+ TATYANA - It's Over
+ Tei Shi - Valerie
+ Luke Temple and The Cascading Moms - Certain Limitations
+ Gabriel Teodros - Embers
+ Terror Cactus - Forastero
+ Terror/Cactus & Cuervo Cuervo - Agua Mágica
+ TeZATalks - Black Girl American Horror Story
+ Thandii - Dream With You / Come As You
+ Thavoron - Thavoron
+ Thee Heart Tones - Forever & Ever
+ Thee Marloes - Perak
+ Thee Sacred Souls - Got A Story To Tell
+ Thee Sinseers - Sinseerly Yours
+ The The - Ensoulment
+ They Hate Change - Wish You Were Here...
+ Think About You - Don't Die On Me
+ This Is Lorelei - Box for Boddy, Box for Star
+ Thunderpussy - West
+ THUS LOVE - All Pleasure
+ Tiger & Woods - Dancing Without Headphones
+ Ana Tijoux - Vida
+ Mary Timony - Untame The Tiger
+ Tipa Tipo - Cintas
+ Anna Tivel - Living Thing
+ toe - NOW I SEE THE LIGHT
+ Tomato Flower - No
+ Tony H - Who's In Control
+ Topographies - Interior Spring
+ Toro Y Moi - Hole Erth
+ TORRES - What an enormous room
+ Torrey - Torrey
+ Trace Mountains - Into the Burning Blue
+ trauma ray - Chameleon
+ Trentemøller - Dreamweaver
+ Benny Trokan - Do You Still Think of Me
+ TR/ST - Performance
+ TR/ST - TR/ST
+ TSHA - Sad Girl
+ Rosie Tucker - Utopia Now!
+ TV Star & Spiral XP - TVXP EP
+ Two Shell - Two Shell
+ Tycho - Infinite Health
+ Tyla - TYLA
+ Kali Uchis - Orquídeas
+ The Umbrellas - Fairweather Friend
+ Underworld - Strawberry Hotel
+ UTO - When all you want to do is be the fire part of fire
+ Sofía Valdés - Sofía Valdés
+ Valebol - Valebol
+ Marcos Valle - Túnel Acústico
+ Vampire Weekend - Only God Was Above Us
+ Van Houten - The Tallest Room
+ Various Artists - Hearts & Minds & Crooked Beats: Songs of The Clash
+ Various Artists - 45èmes Rencontres Trans Musicales de Rennes
+ Various Artists - Ball of Wax Volume 69: Duos
+ Various Artists - DPER KYAKU
+ Various Artists - Big Crown Records presents Crown Jewels Vol. 3
+ Various Artists - My Black Country: The Songs of Alice Randall
+ Various Artists - Everyone’s Getting Involved: A Tribute To Talking Heads’ Stop Making Sense
+ Various Artists - I Saw the TV Glow
+ Various Artists - Ghana Special 2: Electronic Highlife & Afro Sounds in the Diaspora, 1980-93
+ Various Artists - Musicians for a Free Palestine
+ Various Artists - From Far It All Seems Small
+ Various Artists - Kampire Presents: A Dancefloor in Ndola
+ Various Artists - Synthesizing the Silk Roads: Uzbek Disco, Tajik 
+ Various Artists - Jazz Is Dead 021
+ Various Artists - NOISE FOR NOW: VOl. 2
+ Various Artists - Scenic Route - Road Less Travelled, Vol. 2
+ Various Artists - The Power of the Heart: A Tribute to Lou Reed
+ Various Artists - American Football (Covers)
+ Various Artists - Like Someone I Know: A Celebration of Margo Guryan
+ Kenya Vaun - The Honeymoon Phase
+ Vegyn - The Road to Hell Is Paevd With Good Intentions
+ Vessel - Wrapped In Cellohphane
+ Villager - NOWHERE FM: THE BROOM OF THE SYSTEM
+ villagerrr - Tear Your Heart Out
+ Cléa Vincent - Ad vitam æternamour
+ Vitesse X - This Infinite
+ voyeur - Something Becomes You
+ Hana Vu - Romanticism
+ THE WAEVE - City Lights
+ Wahid - feast, by ravens EP
+ Wahid - THEY ALL GO MAD!
+ Elsy Wameyo - Saint Sinner
+ Wand - Vertigo
+ Warren Dunes - Aquamarine
+ Washed Out - Notes From a Quiet Life
+ Kamasi Washington - Fearless Movement
+ Suki Waterhouse - Memoirs of a Sparklemuffin
+ Waxahatchee - Tigers Blood
+ We Are the Willows - IV
+ Jane Weaver - Love In Constant pectacle
+ Faye Webster - Underdressed at the Symphony
+ Gillian Welch & David Rawlings - Woodland
+ Asha Wells - Tears Of A Clown EP
+ Devon Welsh - Come With Me If You Want To Live
+ Tierra Whack - WORLD WIDE WHACK
+ Jack White - No Name
+ Whitelands - Night-bound Eyes Are Blind to the Day
+ W. H. Lung - Every Inch of Earth Pulsates
+ WHY? - The Will I Fell Into
+ Why Bonnie - Wish on the Bone
+ Wilco - Hot Sun Cool Shroud EP
+ Wild Pink - Dulling The Horns
+ Wild Powwers - Pop Hits & Total Bummers Vol. 5
+ Charlotte Day Wilson - Cyan Blue
+ Wine Lips - Super Mega Ultra
+ Wiseboy Jeremy - Pumpkin Seeds
+ Wiseboy Jeremy - 635
+ Wishy - Triple Seven
+ Wisp - Pandora EP
+ wojtek the bear - shaking hands with the NME
+ Chelsea Wolfe - She Reaches Out to She Reaches Out to She
+ Remi Wolf - Big Ideas
+ Wonder 45 - Wonderland
+ wonderbug - scrap EP
+ Woods - Five More Flowers EP
+ World Brain - Open Source
+ Wu-Lu - Learning to Swim on Empty
+ Wunderhorse - Midas
+ X - Smoke & Fiction
+ xiexie - wellwell
+ Yannis & The Yaw - Lagos Paris London EP
+ Jonah Yano - Jonah Yano & The Heavy Loop
+ Nilüfer Yanya - My Method Actor
+ Yard Act - Where's My Utopia?
+ Scott Yoder - Scooter Pie
+ Jharis Yokley - Sometimes, Late At Night
+ Nao Yoshioka - Flow
+ youbet - Way To Be
+ Young Bae - 6AE
+ Adrian Younge - Linear Labs: São Paulo
+ Young Jesus - The Fool
+ Your Old Droog - Movie
+ The Zawose Queens - Miasha
+ ZG - Out of the Unknown
+ Tucker Zimmerman - Dance of Love
+ Zsela - Big For You
+ mui zyu - nothing or something to die for

--- a/main.py
+++ b/main.py
@@ -1,388 +1,14 @@
-from langchain_community.document_loaders import BSHTMLLoader
-from langchain_text_splitters import RecursiveCharacterTextSplitter 
 from langchain_openai import ChatOpenAI
 from langchain.chains import RetrievalQA
 from langchain_openai import OpenAIEmbeddings
 from langchain_community.vectorstores import Chroma
 from langchain_chroma import Chroma
-from langchain_community.document_loaders import WikipediaLoader
 from langchain.prompts import PromptTemplate
-import re
 import os
-import colorama
 from dotenv import load_dotenv
 import pprint
-from requests.exceptions import ConnectionError
-import time
-import random
+from music_parser_service import MusicParserService
 import uuid
-
-
-def progress_bar(progress, total, color=colorama.Fore.GREEN):
-    '''Progress bar for running time display'''
-    percent = 100 * (progress/ float(total))
-    #alt + 219
-    prog_bar = '█' * int(percent) + '-' * int(100 - percent)
-    # \r ensures the same line is used '\repeat'
-    print(color + f"\r|{prog_bar}| {percent:.2f}%", end="\r")
-
-    if percent == total:
-        print(colorama.Fore.GREEN + f"\r|{prog_bar}| {percent:.2f}%", end="\r")
-
-def chunk_best_of_24_list(page_content):
-    '''chunks each line of the albums listed within the webpage'''
-    splitter = RecursiveCharacterTextSplitter(
-                separators=["\n\n", "\n"],      
-                chunk_size=50,
-                chunk_overlap=5
-                ) 
-
-    album_data = splitter.split_documents(page_content)
-
-    return album_data
-
-def load_kexp_album_documents():
-    documents = []
-
-    loader = BSHTMLLoader("./Vote for KEXP's Best of 2024.html")
-    kexp_best_of_24 = loader.load()
-
-    page_content = kexp_best_of_24[0].page_content
-
-    # extract the artists and their albums
-    found_albums = extract_artists(page_content=page_content)
-    
-    # get articles about the artists
-    band_related_articles = wiki_search_bands(album_list=found_albums)
-
-    # get articles about the album
-    album_related_articles = wiki_search_albums(album_list=found_albums)
-
-    # supply the html page content to be embedded
-    album_data = chunk_best_of_24_list(page_content=kexp_best_of_24)
-    documents.extend(album_data)
-
-    # supply the band information to be embedded
-    for band_article in band_related_articles:
-        documents.extend(band_article)
-
-    # # supply the album information to be embedded
-    for album_article in album_related_articles:
-        documents.extend(album_article)
-
-    return documents
-
-
-# determine artists to wiki walk:
-def extract_artists(page_content):
-    '''determines artists list for wikipedia extraction'''
-    artist_album_regex = r'(.* - .*)'
-
-    matches = re.findall(artist_album_regex, page_content)
-
-    # see matches:
-    # for match in enumerate(matches):
-    #     print(f'Artist - Album: {match}' )
-
-    if matches:
-        return matches
-    else:
-        return []
-
-def get_artist_album(artist_album, artist=False, album=False):
-    '''snags either artist or band data depending on the boolean supplied'''
-    album_regex = r'(.*) - (.*)'
-
-    match_found = re.search(album_regex, artist_album)
-
-    if match_found:
-        groups = match_found.groups()
-        if artist:
-            return groups[0]
-        if album:
-            return groups[1]
-        
-    return -1
-
-
-def wiki_search_bands(album_list):
-    '''queries wikipedia for band details'''
-    
-    back_off_throttle = 15
-
-    band_related_articles = []
-    
-    print('Wiki Searching Band Details from 2024 List...')
-
-    if "bands.txt" not in os.listdir():
-        searched_bands = 0
-        total_albums = len(album_list)-1
-        # open the file and create a running list of parsed albums
-        with open("bands.txt","a") as bands_file:
-            for band in album_list:
-                # {something-artist} - {something-album}
-                progress_bar(progress=searched_bands, total=total_albums)
-                band = get_artist_album(artist_album=band, artist=True)
-                band = band.strip()
-                # query for album information
-                retries = 3
-                for attempt in range(retries):
-                    try:
-                        articles = WikipediaLoader(query=band, load_max_docs=3).load()
-                    except ConnectionError as e:
-                        if attempt < retries:
-                            print("ConnectionError: pulling back on request time")
-                            time.sleep(back_off_throttle * (2 ** attempt))
-                        else:
-                            # long nap.. :(
-                            # wait a random time between 100-600 seconds
-                            time.sleep(100 * random.randint(1,6))
-
-                searched_bands += 1
-                for article in articles:
-                    article_title = article.metadata['title']
-
-                    if article_title in band:
-                        article = chunk_wiki_content(article=article)
-                        band_related_articles.append(article)
-                        bands_file.write(f'{band} \n')
-                    else:
-                        # case where it's an ambiguous name
-                        band_regex = r'\(band\)'
-                        # search articles for band_regex
-                        if re.search(band_regex, article_title):
-                            article = chunk_wiki_content(article=article)
-                            band_related_articles.append(article)
-                            bands_file.write(f'{band}\n')
-                        else:
-                            continue
-            print(colorama.Fore.RESET)
-            print('Finished Wiki Searching Bands...')
-            # close the file.
-            bands_file.close()
-            return band_related_articles
-    else:
-        # need to get the latest album found and skip the line 
-        with open("bands.txt","r") as bands:
-            read_band_list = bands.readlines()
-            bands.close()
-
-        # reopen the file to append more bands.
-        with open("bands.txt", "a") as bands_file:
-            # get the last artist searched.
-            last_band_searched = get_artist_album(artist_album=read_band_list[-1], artist=True)
-            last_band = last_band_searched.strip()
-
-            band_restart_idx = 0
-            for idx, band in enumerate(album_list):
-                # strips for band/artist
-                band = get_artist_album(artist_album=band, artist=True)
-                band = band.strip()
-
-                if band != last_band:
-                    continue
-                else:
-                    # found your starting point.
-                    band_restart_idx = idx
-                    break
-            
-            remaining_bands = album_list[band_restart_idx]
-            # start where you left off.
-            for band in remaining_bands:
-                # {something-artist} - {something-album}
-                progress_bar(progress=searched_bands, total=total_albums)
-                band = get_artist_album(artist_album=band, artist=True)
-                band = band.strip()
-                # query for album information
-                retries = 3
-                for attempt in range(retries):
-                    try:
-                        articles = WikipediaLoader(query=band, load_max_docs=3).load()
-                    except ConnectionError as e:
-                        if attempt < retries:
-                            print("ConnectionError: pulling back on request time")
-                            time.sleep(back_off_throttle * (2 ** attempt))
-                        else:
-                            # long nap.. :(
-                            # wait a random time between 100-600 seconds
-                            time.sleep(100 * random.randint(1,6))
-
-                searched_bands += 1
-                for article in articles:
-                    article_title = article.metadata['title']
-
-                    if article_title in band:
-                        article = chunk_wiki_content(article=article)
-                        band_related_articles.append(article)
-                        bands_file.write(f'{band} \n')
-                    else:
-                        # case where it's an ambiguous name
-                        band_regex = r'\(band\)'
-                        # search articles for band_regex
-                        if re.search(band_regex, article_title):
-                            article = chunk_wiki_content(article=article)
-                            band_related_articles.append(article)
-                            bands_file.write(f'{band}\n')
-                        else:
-                            continue
-            print(colorama.Fore.RESET)
-            print('Finished Wiki Searching Bands...')
-            # close the file.
-            bands_file.close()
-            return band_related_articles
-
-
-def wiki_search_albums(album_list):
-    '''queries wikipedia for album details and band details'''
-    
-    back_off_throttle = 15
-
-    album_related_articles = []
-    print('Wiki Searching Album Details from 2024 List...')
-    if "albums.txt" not in os.listdir():
-        searched_albums = 0
-        total_albums = len(album_list)-1
-        # create a albums file list for a running tally
-        with open("albums.txt","a") as albums_file:
-            for album in album_list:
-                # remove white space
-                progress_bar(progress=searched_albums, total=total_albums)
-                album = get_artist_album(artist_album=album,album=True)
-                album = album.strip()
-                # query for album information
-                retries = 3
-                for attempt in range(retries):
-                    try: 
-                        articles = WikipediaLoader(query=album.strip(), load_max_docs=3).load()
-                    except ConnectionError as e:
-                        if attempt < retries:
-                            print(f"Connection error on attempt: {attempt + 1}: {e}")
-                            time.sleep(back_off_throttle * (2 ** attempt))
-                        else:
-                            # long nap.. :(
-                            # wait a random time between 100-600 seconds
-                            time.sleep(100 * random.randint(1,6))
-                
-                searched_albums += 1
-                for article in articles:
-                    article_title = article.metadata['title']
-                    # search articles for band_regex
-                    if article_title in album:
-                        article = chunk_wiki_content(article=article)
-                        album_related_articles.append(article)
-                        # add the band to the list
-                        albums_file.write(f'{album}\n')
-                    else:
-                        # case where it's an ambiguous name
-                        album_regex = r'\(album\)'
-                        # search articles for band_regex
-                        if re.search(album_regex, article_title):
-                            article = chunk_wiki_content(article=article)
-                            album_related_articles.append(article)
-                            # add the band to the list
-                            albums_file.write(f'{album}\n')
-                        else:
-                            continue
-
-            albums_file.close()
-
-            print(colorama.Fore.RESET)
-            print('Finished Chunking ALbums...')
-            return album_related_articles
-    else:
-        searched_albums = 0
-        total_albums = len(album_list)-1
-        # assume the file exists and check the list
-        with open("albums.txt","r") as albums:
-            read_albums_list = albums.readlines()
-            albums.close()
-
-        # reopen file to add to it.
-        with open("albums.txt", "a") as albums_file:
-            # get the last read band
-            last_album_searched = get_artist_album(artist_album=read_albums_list[-1], album=True)
-            last_album = last_album_searched.strip()
-
-            album_restart_indx = 0
-            for idx, album in enumerate(album_list):
-                album = get_artist_album(artist_album=album, album=True)
-                # remove wite space
-                album = album.strip()
-
-                if album != last_album:
-                    continue
-                else:
-                    album_restart_indx = idx
-                    searched_albums = idx
-                    break
-
-            remaining_albums = album_list[album_restart_indx]
-            # iterate through the remaining items
-            for album in remaining_albums:
-                # remove white space
-                progress_bar(progress=searched_albums, total=total_albums)
-                album = get_artist_album(artist_album=album,album=True)
-                album = album.strip()
-                # query for album information
-                retries = 3
-                for attempt in range(retries):
-                    try: 
-                        articles = WikipediaLoader(query=album.strip(), load_max_docs=3).load()
-                    except ConnectionError as e:
-                        if attempt < retries:
-                            print(f"Connection error on attempt: {attempt + 1}: {e}")
-                            time.sleep(back_off_throttle * (2 ** attempt))
-                        else:
-                            # long nap.. :(
-                            # wait a random time between 100-600 seconds
-                            time.sleep(100 * random.randint(1,6))
-                
-                searched_albums += 1
-                for article in articles:
-                    article_title = article.metadata['title']
-                    # search articles for band_regex
-                    if article_title in album:
-                        article = chunk_wiki_content(article=article)
-                        album_related_articles.append(article)
-                        # add the band to the list
-                        albums_file.write(album)
-                    else:
-                        # case where it's an ambiguous name
-                        album_regex = r'\(album\)'
-                        # search articles for band_regex
-                        if re.search(album_regex, article_title):
-                            article = chunk_wiki_content(article=article)
-                            album_related_articles.append(article)
-                            # add the band to the list
-                            albums_file.write(album)
-                        else:
-                            continue
-
-        print(colorama.Fore.RESET)
-        print('Finished Chunking ALbums...')
-        return album_related_articles
-
-
-def chunk_wiki_content(article):
-    '''takes article text as input and chunks the results for embedding'''
-
-    splitter = RecursiveCharacterTextSplitter(
-                    separators=['\n','\n\n', '.', ' '],
-                    chunk_size=100, 
-                    chunk_overlap=20,
-                    length_function=len,
-                    is_separator_regex=False
-                ) 
-    
-    # Wrap the article in a list if it's a single Document object
-    if not isinstance(article, list):
-        article = [article]
-    
-    # Ensure the article is a Document object
-    data = splitter.split_documents(article)
-
-    return data
-
 
 
 def main():
@@ -401,7 +27,7 @@ def main():
     open_ai_gpt_4o_mini = ChatOpenAI(
         model="gpt-4o-mini",
         temperature=0,
-        max_tokens=45, 
+        max_tokens=200, 
         api_key=OPEN_AI_API_KEY,
         timeout=30
     )
@@ -417,11 +43,12 @@ def main():
     # ======================
 
     if "chroma_db" not in os.listdir():
-        documents = load_kexp_album_documents()
+        music_parser = MusicParserService()
+        music_documents = music_parser.load_kexp_album_documents()
         # supply the chunked documents and the embedding model chroma db
         vector_store = Chroma.from_documents(     
-                            documents=documents,   
-                            ids=[str(uuid.uuid4()) for _ in documents],   
+                            documents=music_documents,   
+                            ids=[str(uuid.uuid4()) for _ in music_documents],   
                             embedding=embedding_model,
                             collection_name="KEXP-24-Embeddings", 
                             persist_directory='chroma_db',
@@ -435,12 +62,17 @@ def main():
             collection_name="KEXP-24-Embeddings"
         )
 
-    
+        # there might have been errors from the previous kexp parse
+        music_parser = MusicParserService()
+        music_documents = music_parser.load_kexp_album_documents()
+
+        if len(music_documents) != 0:            
+            vector_store.add_documents(documents=music_documents, ids=[str(uuid.uuid4()) for _ in music_documents])
     
     # # set up chroma to be the retriever for related documents based on the embedding
     retriever = vector_store.as_retriever(
         search_type="similarity",
-        search_kwargs={"k": 2}
+        search_kwargs={"k": 3}
     )
 
 
@@ -468,7 +100,7 @@ def main():
 
 
     pprint.pprint(
-        qa_with_source("")
+        qa_with_source("Tell me about Beak> in 2024.")
     )
 
 main()

--- a/music_parser_service.py
+++ b/music_parser_service.py
@@ -1,0 +1,426 @@
+from langchain_community.document_loaders import BSHTMLLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter 
+from langchain_openai import ChatOpenAI
+from langchain.chains import RetrievalQA
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_chroma import Chroma
+from langchain_community.document_loaders import WikipediaLoader
+from langchain.prompts import PromptTemplate
+import re
+import os
+import colorama
+from dotenv import load_dotenv
+import pprint
+from requests.exceptions import ConnectionError
+from requests.exceptions import ReadTimeout
+from file_empty import FileEmpty
+import time
+import random
+import uuid
+
+class MusicParserService():
+    def __init__(self):
+        # default timeout parameter
+        self.wiki_timeout = False    
+
+    def progress_bar(self, progress, total, color=colorama.Fore.GREEN):
+        '''Progress bar for running time display'''
+        percent = 100 * (progress/ float(total))
+        #alt + 219
+        prog_bar = '█' * int(percent) + '-' * int(100 - percent)
+        # \r ensures the same line is used '\repeat'
+        print(color + f"\r|{prog_bar}| {percent:.2f}%", end="\r")
+
+        if percent == total:
+            print(colorama.Fore.GREEN + f"\r|{prog_bar}| {percent:.2f}%", end="\r")
+
+    def chunk_best_of_24_list(self, page_content):
+        '''chunks each line of the albums listed within the webpage'''
+        splitter = RecursiveCharacterTextSplitter(
+                    separators=["\n\n", "\n"],      
+                    chunk_size=50,
+                    chunk_overlap=5
+                    ) 
+
+        album_data = splitter.split_documents(page_content)
+
+        return album_data
+
+    def load_kexp_album_documents(self):
+        documents = []
+
+        loader = BSHTMLLoader("./Vote for KEXP's Best of 2024.html")
+        kexp_best_of_24 = loader.load()
+
+        page_content = kexp_best_of_24[0].page_content
+
+        # extract the artists and their albums
+        found_albums = self.extract_artists(page_content=page_content)
+        
+        #limit the alums within the wiki search
+        found_albums = found_albums
+
+        # get articles about the artists
+        band_related_articles = self.wiki_search_bands(album_list=found_albums)
+
+        # wait like ~20 minutes
+        time.sleep(1200)
+
+        # get articles about the album
+        album_related_articles = self.wiki_search_albums(album_list=found_albums)
+
+        # supply the html page content to be embedded
+        album_data = self.chunk_best_of_24_list(page_content=kexp_best_of_24)
+        documents.extend(album_data)
+
+        # supply the band information to be embedded
+        for band_article in band_related_articles:
+            documents.extend(band_article)
+
+        # # supply the album information to be embedded
+        for album_article in album_related_articles:
+            documents.extend(album_article)
+
+        return documents
+
+
+    # determine artists to wiki walk:
+    def extract_artists(self, page_content):
+        '''determines artists list for wikipedia extraction'''
+        artist_album_regex = r'(.* - .*)'
+
+        matches = re.findall(artist_album_regex, page_content)
+
+        # see matches:
+        # for match in enumerate(matches):
+        #     print(f'Artist - Album: {match}' )
+
+        if matches:
+            return matches
+        else:
+            return []
+
+    def get_artist_album(self, artist_album, artist=False, album=False):
+        '''snags either artist or band data depending on the boolean supplied'''
+        album_regex = r'(.*) - (.*)'
+
+        match_found = re.search(album_regex, artist_album)
+
+        if match_found:
+            groups = match_found.groups()
+            if artist:
+                return groups[0]
+            if album:
+                return groups[1]
+            
+        return -1
+
+
+    def wiki_search_bands(self, album_list):
+        '''queries wikipedia for band details'''
+        
+        back_off_throttle = 15
+
+        band_related_articles = []
+        
+        print('Wiki Searching Band Details from 2024 List...')
+
+        if "bands.txt" not in os.listdir():
+            searched_bands = 0
+            total_albums = len(album_list)-1
+            # open the file and create a running list of parsed albums
+            with open("bands.txt",'a', encoding='utf-8') as bands_file:
+                for band in album_list:
+                    # {something-artist} - {something-album}
+                    self.progress_bar(progress=searched_bands, total=total_albums)
+                    band = self.get_artist_album(artist_album=band, artist=True)
+                    band = band.strip()
+                    # query for album information
+                    retries = 3
+                    for attempt in range(retries):
+                        try:
+                            articles = WikipediaLoader(query=band, load_max_docs=3).load()
+                        except ConnectionError as e:
+                            if attempt < retries:
+                                print("ConnectionError: pulling back on request time")
+                                time.sleep(back_off_throttle * (2 ** attempt))
+                            else:
+                                # long nap.. :(
+                                # wait a random time between 100-600 seconds
+                                time.sleep(100 * random.randint(1,6))
+                        except ReadTimeout as e:
+                            print("ReadTimeout occurred returning everything captured thus far.")
+                            # return everything captured thus far
+                            self.wiki_timeout = True
+                            bands_file.close()
+                            return band_related_articles
+
+                    searched_bands += 1
+                    for article in articles:
+                        article_title = article.metadata['title']
+
+                        if article_title in band:
+                            article = self.chunk_wiki_content(article=article)
+                            band_related_articles.append(article)
+                            bands_file.write(f'{band} \n')
+                        else:
+                            # case where it's an ambiguous name
+                            band_regex = r'\(band\)'
+                            # search articles for band_regex
+                            if re.search(band_regex, article_title):
+                                article = self.chunk_wiki_content(article=article)
+                                band_related_articles.append(article)
+                                bands_file.write(f'{band}\n')
+                            else:
+                                continue
+                print(colorama.Fore.RESET)
+                print('Finished Wiki Searching Bands...')
+                # close the file.
+                bands_file.close()
+                return band_related_articles
+        else:
+            # need to get the latest album found and skip the line 
+            with open("bands.txt", 'r', encoding='utf-8') as bands_file:
+                read_band_list = bands_file.readlines()
+                if len(read_band_list) == 0:
+                    raise FileEmpty("bands.txt is empty. delete bands.txt")
+
+            # reopen the file to append more bands.
+            with open("bands.txt", "a") as bands_file:
+                # get the last artist searched.
+                last_band_searched = read_band_list[-1]
+                last_band = last_band_searched.strip('\n')
+
+                band_restart_idx = 0
+                for idx, band in enumerate(album_list):
+                    # strips for band/artist
+                    band = self.get_artist_album(artist_album=band, artist=True)
+                    band = band.strip()
+
+                    if band != last_band:
+                        continue
+                    else:
+                        # found your starting point.
+                        band_restart_idx = idx
+                        break
+                # slice from 85:EoL
+                remaining_bands = album_list[band_restart_idx:]
+                # start where you left off.
+                searched_bands = 0
+                # collect remaining total
+                remaining_albums = len(remaining_bands)
+                for remaining_band in remaining_bands:
+                    # {something-artist} - {something-album}
+                    self.progress_bar(progress=searched_bands, total=remaining_albums)
+                    band = self.get_artist_album(artist_album=remaining_band, artist=True)
+                    band = band.strip()
+                    # query for album information
+                    retries = 3
+                    for attempt in range(retries):
+                        try:
+                            articles = WikipediaLoader(query=band, load_max_docs=3).load()
+                        except ConnectionError as e:
+                            if attempt < retries:
+                                print("ConnectionError: pulling back on request time")
+                                time.sleep(back_off_throttle * (2 ** attempt))
+                            else:
+                                # long nap.. :(
+                                # wait a random time between 100-600 seconds
+                                time.sleep(100 * random.randint(1,6))
+                        except ReadTimeout as e:
+                            print("ReadTimeout occurred returning everything captured thus far.")
+                            # return everything captured thus far
+                            bands_file.close()
+                            return band_related_articles
+
+                    searched_bands += 1
+                    for article in articles:
+                        article_title = article.metadata['title']
+
+                        if article_title in band:
+                            article = self.chunk_wiki_content(article=article)
+                            band_related_articles.append(article)
+                            bands_file.write(f'{band} \n')
+                        else:
+                            # case where it's an ambiguous name
+                            band_regex = r'\(band\)'
+                            # search articles for band_regex
+                            if re.search(band_regex, article_title):
+                                article = self.chunk_wiki_content(article=article)
+                                band_related_articles.append(article)
+                                bands_file.write(f'{band}\n')
+                            else:
+                                continue
+                print(colorama.Fore.RESET)
+                print('Finished Wiki Searching Bands...')
+                # close the file.
+                bands_file.close()
+                return band_related_articles
+
+
+    def wiki_search_albums(self, album_list):
+        '''queries wikipedia for album details and band details'''
+        
+        back_off_throttle = 15
+
+        album_related_articles = []
+        print('Wiki Searching Album Details from 2024 List...')
+        if "albums.txt" not in os.listdir():
+            searched_albums = 0
+            total_albums = len(album_list)-1
+            # create a albums file list for a running tally
+            with open("albums.txt","a") as albums_file:
+                for album in album_list:
+                    # remove white space
+                    self.progress_bar(progress=searched_albums, total=total_albums)
+                    album = self.get_artist_album(artist_album=album,album=True)
+                    album = album.strip()
+                    # query for album information
+                    retries = 3
+                    for attempt in range(retries):
+                        try: 
+                            articles = WikipediaLoader(query=album.strip(), load_max_docs=3).load()
+                        except ConnectionError as e:
+                            if attempt < retries:
+                                print(f"Connection error on attempt: {attempt + 1}: {e}")
+                                time.sleep(back_off_throttle * (2 ** attempt))
+                            else:
+                                # long nap.. :(
+                                # wait a random time between 100-600 seconds
+                                time.sleep(100 * random.randint(1,6))
+                        except ReadTimeout as e:
+                            print("ReadTimeout occurred returning everything captured thus far.")
+                            self.wiki_timeout = True
+                            # return everything captured thus far
+                            albums_file.close()
+                            return album_related_articles
+                    
+                    searched_albums += 1
+                    for article in articles:
+                        article_title = article.metadata['title']
+                        # search articles for band_regex
+                        if article_title in album:
+                            article = self.chunk_wiki_content(article=article)
+                            album_related_articles.append(article)
+                            # add the band to the list
+                            albums_file.write(f'{album}\n')
+                        else:
+                            # case where it's an ambiguous name
+                            album_regex = r'\(album\)'
+                            # search articles for band_regex
+                            if re.search(album_regex, article_title):
+                                article = self.chunk_wiki_content(article=article)
+                                album_related_articles.append(article)
+                                # add the band to the list
+                                albums_file.write(f'{album}\n')
+                            else:
+                                continue
+
+                albums_file.close()
+
+                print(colorama.Fore.RESET)
+                print('Finished Chunking ALbums...')
+                return album_related_articles
+        else:
+            searched_albums = 0
+            total_albums = len(album_list)-1
+            # assume the file exists and check the list
+            with open("albums.txt","r") as albums:
+                read_albums_list = albums.readlines()
+                if len(read_albums_list) == 0:
+                    raise FileEmpty("albums.txt is empty. delete albums.txt")
+
+            # reopen file to add to it.
+            with open("albums.txt", "a") as albums_file:
+                # get the last read band
+                last_album_searched = read_albums_list[-1]
+                last_album = last_album_searched.strip('\n')
+
+                album_restart_indx = 0
+                for idx, album in enumerate(album_list):
+                    # remove wite space
+                    album = self.get_artist_album(artist_album=album, album=True)
+                    album = album.strip()
+
+                    if album != last_album:
+                        continue
+                    else:
+                        album_restart_indx = idx
+                        break
+
+                remaining_albums = album_list[album_restart_indx:]
+                # start where you left off.
+                searched_albums = 0
+                # collect th remaining total
+                remaining_albums = len(remaining_albums)
+                # iterate through the remaining items
+                for remaining_album in remaining_albums:
+                    # remove white space
+                    self.progress_bar(progress=searched_albums, total=total_albums)
+                    album = self.get_artist_album(artist_album=remaining_album,album=True)
+                    album = album.strip()
+                    # query for album information
+                    retries = 3
+                    for attempt in range(retries):
+                        try: 
+                            articles = WikipediaLoader(query=album.strip(), load_max_docs=3).load()
+                        except ConnectionError as e:
+                            if attempt < retries:
+                                print(f"Connection error on attempt: {attempt + 1}: {e}")
+                                time.sleep(back_off_throttle * (2 ** attempt))
+                            else:
+                                # long nap.. :(
+                                # wait a random time between 100-600 seconds
+                                time.sleep(100 * random.randint(1,6))
+                        except ReadTimeout as e:
+                            print("ReadTimeout occurred returning everything captured thus far.")
+                            # return everything captured thus far
+                            albums_file.close()
+                            return album_related_articles
+                    
+                    searched_albums += 1
+                    for article in articles:
+                        article_title = article.metadata['title']
+                        # search articles for band_regex
+                        if article_title in album:
+                            article = self.chunk_wiki_content(article=article)
+                            album_related_articles.append(article)
+                            # add the band to the list
+                            albums_file.write(album)
+                        else:
+                            # case where it's an ambiguous name
+                            album_regex = r'\(album\)'
+                            # search articles for band_regex
+                            if re.search(album_regex, article_title):
+                                article = self.chunk_wiki_content(article=article)
+                                album_related_articles.append(article)
+                                # add the band to the list
+                                albums_file.write(album)
+                            else:
+                                continue
+
+            print(colorama.Fore.RESET)
+            print('Finished Chunking ALbums...')
+            return album_related_articles
+
+
+    def chunk_wiki_content(self,article):
+        '''takes article text as input and chunks the results for embedding'''
+
+        splitter = RecursiveCharacterTextSplitter(
+                        separators=['\n','\n\n', '.', ' '],
+                        chunk_size=100, 
+                        chunk_overlap=20,
+                        length_function=len,
+                        is_separator_regex=False
+                    ) 
+        
+        # Wrap the article in a list if it's a single Document object
+        if not isinstance(article, list):
+            article = [article]
+        
+        # Ensure the article is a Document object
+        data = splitter.split_documents(article)
+
+        return data

--- a/readme.md
+++ b/readme.md
@@ -3,16 +3,34 @@
 for the year of 2024, I have been busier than I have been in the past two years. Overwhelmed, I have decided to relax this year when KEXP released their ever popular **Best of** releases. It's common for a voting system to be deployed and gosh darn it, it often feels like a ticking time bomb. I want to be more than an advid sidliner, I want to be an informed voter... I mean look at this [list](https://www.kexp.org/countdowns/best-of-2024/) its friggin MASSIVE. So for 2024 Enter the Best of KEXP Chatbot 📻 🤖 . Allowing an LLM to do the heavy lifting and experimenting with it's ability to recommend music to me based on this year's releases, seems fairly relaxing, and takes the stress of playlist queueing out of my hands and directly into my brain holes. 🧠 🥹. 
 
 
+### LangChain
+
+#### Models
+
+#### Chains 
+
+#### Retrieval Augmented Generation 
+
+
 
 ### Chroma DB
 
+#### Adding Documents
+
+#### Persisting Document Data 
+
+#### Querying Documents
+
+
+### StreamLit
 
 
 
 ### Documentation
 
-[Mistral AI]()
-[OpenAI]()
-[LangChain]()
-[Chroma DB](https://docs.trychroma.com/getting-started)
+[Mistral AI](https://python.langchain.com/docs/integrations/chat/mistralai/)
+[OpenAI](https://python.langchain.com/docs/integrations/chat/openai/)
+[LangChain](https://python.langchain.com/docs/tutorials/)
+[LangSmith](https://docs.smith.langchain.com/)
+[LangChain Chroma DB](https://python.langchain.com/docs/integrations/vectorstores/chroma/)
 [Tommy Codes Chroma DB Benefits and Demonstration](https://www.youtube.com/watch?v=QSW2L8dkaZk&t=184s)

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,4 @@ for the year of 2024, I have been busier than I have been in the past two years.
 [OpenAI]()
 [LangChain]()
 [Chroma DB](https://docs.trychroma.com/getting-started)
+[Tommy Codes Chroma DB Benefits and Demonstration](https://www.youtube.com/watch?v=QSW2L8dkaZk&t=184s)


### PR DESCRIPTION
* Integrates LangSmith Tracking
* builds an external service `music_parser_service`

**MusicParserService** 

handles the breaking down of the music by band and album for 2024. This service also caches, a place it left off and splits the overall number of music for this list by dividing the remaining albums `remaining_albums // 4` to allow for smaller consecutive hits agains the `wikipedia` api. 